### PR TITLE
Missing checker reject for input traffic

### DIFF
--- a/ansible/roles/docker-block-external/tasks/main.yml
+++ b/ansible/roles/docker-block-external/tasks/main.yml
@@ -19,8 +19,8 @@
       jump: RETURN
       state: absent
 
-  - name: "REJECT MISSING-CHECKER TRAFFIC"
-    iptablees:
+  - name: "REJECT missing checker-traffic"
+    iptables:
       chain: INPUT
       jump: REJECT
 

--- a/ansible/roles/docker-block-external/tasks/main.yml
+++ b/ansible/roles/docker-block-external/tasks/main.yml
@@ -19,5 +19,10 @@
       jump: RETURN
       state: absent
 
+  - name: "REJECT MISSING-CHECKER TRAFFIC"
+    iptablees:
+      chain: INPUT
+      jump: REJECT
+
   - name: persist iptables config
     shell: "iptables-save > /etc/iptables/rules.v4"


### PR DESCRIPTION
Engine does not receive a rejection when attempting to connect to a not existing checker.

> Add iptables rule for rejecting every packet at the end of the INPUT chain