### PR TITLE
change variable names in the checker key gen script

### DIFF
--- a/config/internal_router/gen_keys.sh
+++ b/config/internal_router/gen_keys.sh
@@ -2,7 +2,7 @@
 
 GAME_NETWORK="10.0.0.0/16"
 INTERNAL_NETWORK="192.168.0.0/20"
-TEAM_IP_PREFIX="192.168.1."
+CHECKER_IP_PREFIX="192.168.1."
 ROUTER_ADDRESS="192.168.0.2/20"
 ENGINE_ADDRESS="192.168.1.0/32"
 ROUTER_ENDPOINT=vpn.bambi.ovh:51821
@@ -56,17 +56,17 @@ EOF
 )"
 
 mkdir -p clients
-for team_id in $(seq 1 "$1"); do
-    team_ip="${TEAM_IP_PREFIX}${team_id}"
-    echo $team_ip
+for checker_id in $(seq 1 "$1"); do
+    checker_ip="${CHECKER_IP_PREFIX}${checker_id}"
+    echo $checker_ip
     privkey=$(wg genkey)
     echo $privkey
     pubkey=$(echo "$privkey" | wg pubkey)
     echo $pubkey
-    echo $team_id
-    cat > "clients/team${team_id}.conf" <<EOF
+    echo $checker_id
+    cat > "clients/team${checker_id}.conf" <<EOF
 [Interface]
-Address = $team_ip/32
+Address = $checker_ip/32
 PrivateKey = $privkey
 
 [Peer]
@@ -86,7 +86,7 @@ EOF
 
 [Peer]
 PublicKey = $pubkey
-AllowedIPs = ${team_ip}/32
+AllowedIPs = ${checker_ip}/32
 EOF
 )
 
@@ -95,7 +95,7 @@ EOF
 
 [Peer]
 PublicKey = $pubkey
-AllowedIPs = ${team_ip}/32
+AllowedIPs = ${checker_ip}/32
 EOF
 )
 done

--- a/config/internal_router/gen_keys.sh
+++ b/config/internal_router/gen_keys.sh
@@ -64,7 +64,7 @@ for checker_id in $(seq 1 "$1"); do
     pubkey=$(echo "$privkey" | wg pubkey)
     echo $pubkey
     echo $checker_id
-    cat > "clients/team${checker_id}.conf" <<EOF
+    cat > "clients/checker${checker_id}.conf" <<EOF
 [Interface]
 Address = $checker_ip/32
 PrivateKey = $privkey

--- a/terraform/bambictf.tf
+++ b/terraform/bambictf.tf
@@ -158,7 +158,7 @@ resource "hcloud_server" "checker" {
   user_data = <<TERRAFORMEOF
 #!/bin/sh
 cat <<EOF >> /etc/wireguard/internal.conf
-${file("../config/internal_router/clients/team${count.index + 1}.conf")}
+${file("../config/internal_router/clients/checker${count.index + 1}.conf")}
 EOF
 systemctl enable wg-quick@internal
 systemctl start wg-quick@internal


### PR DESCRIPTION
One thing I noticed is that the `/config` dir is ignored by the .gitignore. not sure if that is intended.