### PR TITLE
Fix docker container loopback with host IP

### DIFF
--- a/ansible/roles/docker/files/daemon.json
+++ b/ansible/roles/docker/files/daemon.json
@@ -7,5 +7,6 @@
 	"default-address-pools": [{
 		"base": "172.17.0.0/16",
 		"size": 24
-	}]
+	}],
+	"userland-proxy": false
 }

--- a/ansible/roles/vulnbox_enomoloch/tasks/main.yml
+++ b/ansible/roles/vulnbox_enomoloch/tasks/main.yml
@@ -79,6 +79,14 @@
     destination_port: "8005"
     jump: DROP
 
+- name: "Block access to moloch from docker containers"
+  iptables:
+    chain: DOCKER-USER
+    protocol: tcp
+    source: "172.17.0.0/16"
+    destination_port: "8005"
+    jump: DROP
+
 - name: Persist iptables config
   include_role:
     name: "iptables_persistent"

--- a/ansible/roles/vulnbox_enomoloch/tasks/main.yml
+++ b/ansible/roles/vulnbox_enomoloch/tasks/main.yml
@@ -82,8 +82,16 @@
 - name: "Block access to moloch from docker containers"
   iptables:
     chain: DOCKER-USER
+    in_interface: docker0
     protocol: tcp
-    source: "172.17.0.0/16"
+    destination_port: "8005"
+    jump: DROP
+
+- name: "Block access to moloch from docker bridges"
+  iptables:
+    chain: DOCKER-USER
+    in_interface: br-+
+    protocol: tcp
     destination_port: "8005"
     jump: DROP
 


### PR DESCRIPTION
When a Docker container attempts to connect to the host machine using the host's IP address, the packets are typically intercepted by the iptables INPUT chain and Docker's userland proxy. While the INPUT chain natively accepts all traffic from the loopback interface, packets originating from the Docker bridge do not use lo. Instead, they enter via the bridge interface, because the host's IP is not considered local from the perspective of the container's isolated network namespace.

To properly allow this traffic using any IP local to the host, this PR disables the Docker userland proxy. By disabling it, Docker is forced to rely entirely on pure in-kernel iptables rules (specifically Hairpin NAT and MASQUERADE) to correctly route the traffic back to the container. Aside from a few edge cases where the userland proxy manages UDP connection states better, relying strictly on kernel-level routing drastically reduces overhead and should also be more performant.