### PR TITLE
Fix vulnbox build potentially failing on image pull

### DIFF
--- a/ansible/roles/vuln_services/tasks/main.yml
+++ b/ansible/roles/vuln_services/tasks/main.yml
@@ -29,7 +29,7 @@
   with_dict: "{{ vulnerable_services }}"
 
 - name: Pull/build service
-  shell: docker compose pull && docker compose build
+  shell: docker compose pull --ignore-buildable && docker compose build
   args:
     chdir: /services/{{ item.key }}
   with_dict: "{{ vulnerable_services }}"


### PR DESCRIPTION
The vulnbox builds could fail if the following docker compose config snippets were used:

```
build: ./deploy
image: mediocre-simh:latest
```

The `docker compose pull` tried to pull the `mediocre-simh:latest` tag from the official docker repo, failed, and then short circuited and failed the entire build. However, that image is buildable, and thus should not crash the vulnbox packing.

Docker image building now Ignores all buildables images, I assume for enowars this will not cause any unexpected behavior (unless someone pushes their enowars image to the docker hub and expects it to be downloaded, and even then packing should succeed due to the build command [1]).

---
[1]: If someone pushes their enowars docker image to the docker hub we have a bigger problem anyway