### PR TITLE
set mtu to 1420

### DIFF
--- a/ansible/roles/docker/files/daemon.json
+++ b/ansible/roles/docker/files/daemon.json
@@ -1,4 +1,10 @@
 {
+	"mtu": 1420,
+	"default-network-opts": {
+		"bridge": {
+			"com.docker.network.driver.mtu": "1420"
+		}
+  	},
 	"log-driver": "json-file",
 	"log-opts": {
 		"max-size": "300m",


### PR DESCRIPTION
This fixes the mtu to 1420 (same as wireguard interface). This fixes the issue that checker traffic is in some cases fingerprintable by looking at the TCP MSS