### PR TITLE
normalize IP TTL to prevent traffic fingerprinting

### DIFF
--- a/ansible/roles/router_iptables/tasks/main.yml
+++ b/ansible/roles/router_iptables/tasks/main.yml
@@ -162,6 +162,11 @@
 - name: Open game network (time-based)
   shell: "iptables -A FORWARD -o router -m time --datestart {{ network_open_time }} --datestop {{ network_close_time }} -j ACCEPT"
 
+# IP Packets can have different TTL based on origin. Checker traffic is partially fingerprintable without this normalization
+- name: Normalize TTL toward vulnboxes
+  shell: "iptables -t mangle -A POSTROUTING -d 10.1.0.0/16 -m ttl --ttl-gt 60 -j TTL --ttl-set 60"
+  when: '"-A POSTROUTING -d 10.1.0.0/16 -m ttl --ttl-gt 60 -j TTL --ttl-set 60" not in iptablessave.stdout'
+
 - name: Persist iptables config
   include_role:
     name: "iptables_persistent"


### PR DESCRIPTION
if the TTL is not normalized, traffic from half the vulnboxes (if not sent from e.g. a docker container to add an extra hop) can be clearly distinguished from checker traffic. without this rule, depending on what router a team is connected to, the traffic from at least half of the other teams could be blocked while leaving all checker traffic through.